### PR TITLE
Fixed app crash and reverted chart types

### DIFF
--- a/dashboards-observability/common/constants/shared.ts
+++ b/dashboards-observability/common/constants/shared.ts
@@ -78,6 +78,13 @@ export enum VIS_CHART_TYPES {
   Pie = 'pie',
   HeatMap = 'heatmap',
   Text = 'text',
+  Gauge = 'gauge',
+  Histogram = 'histogram',
+  TreeMap = 'tree_map',
+  Scatter = 'scatter',
+  LogsView = 'logs_view',
+  Metrics = 'metrics',
+  TableView = 'data_table',
 }
 
 export const NUMERICAL_FIELDS = ['short', 'integer', 'long', 'float', 'double'];

--- a/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_configurations_panel.tsx
+++ b/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_configurations_panel.tsx
@@ -228,6 +228,7 @@ export const DataConfigPanelItem = ({
       const newQuery = queryManager!
         .queryBuilder()
         .build(data.query.rawQuery, composeAggregations(updatedConfigList, statsTokens));
+      handleQueryChange(newQuery);
 
       const updatedQuery = {
         tabId,
@@ -291,10 +292,10 @@ export const DataConfigPanelItem = ({
                     singleSelection={{ asPlainText: true }}
                     options={AGGREGATION_OPTIONS}
                     selectedOptions={
-                      selectedObj.aggregation
+                      selectedObj?.aggregation
                         ? [
                             {
-                              label: selectedObj.aggregation,
+                              label: selectedObj?.aggregation,
                             },
                           ]
                         : []
@@ -304,13 +305,13 @@ export const DataConfigPanelItem = ({
                 </EuiFormRow>
               )}
               {/* Show input fields for Series when aggregation is not empty  */}
-              {isAggregations && selectedObj.aggregation !== '' && (
+              {isAggregations && selectedObj?.aggregation !== '' && (
                 <>
                   {getCommonDimensionsField(selectedObj, name)}
                   <EuiFormRow label="Custom label">
                     <EuiFieldText
                       placeholder="Custom label"
-                      value={selectedObj[CUSTOM_LABEL]}
+                      value={selectedObj && selectedObj[CUSTOM_LABEL]}
                       onChange={(e) => updateList(e.target.value, CUSTOM_LABEL)}
                       aria-label="input label"
                     />
@@ -327,7 +328,7 @@ export const DataConfigPanelItem = ({
                       { id: 'left', label: 'Left' },
                       { id: 'right', label: 'Right' },
                     ]}
-                    idSelected={selectedObj.side || 'right'}
+                    idSelected={selectedObj?.side || 'right'}
                     handleButtonChange={(id: string) => updateList(id, 'side')}
                   />
                 </EuiFormRow>

--- a/dashboards-observability/public/components/visualizations/charts/helpers/viz_types.ts
+++ b/dashboards-observability/public/components/visualizations/charts/helpers/viz_types.ts
@@ -241,8 +241,8 @@ const getUserConfigs = (
         configOfUser = {
           ...userSelectedConfigs,
           dataConfig: {
-            ...userSelectedConfigs?.dataConfig,
             ...defaultUserConfigs(query, visName),
+            ...userSelectedConfigs?.dataConfig,
           },
         };
         break;


### PR DESCRIPTION
Signed-off-by: Koustubh Karmalkar <koustubh_karmalkar@persistent.com>

### Description
- Fixed app crash when series removed and updated the chart
- Reverted the vis_chart_types

### Issues Resolved
https://github.com/opensearch-project/observability/issues/1141

### Check List
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
